### PR TITLE
Closing the AudioContext once it has done recording

### DIFF
--- a/speech.1.0.0.js
+++ b/speech.1.0.0.js
@@ -388,6 +388,7 @@ var Bing;
         };
         Speech.prototype.stop = function () {
             if (this._currentSource) {
+                this.context.close();
                 Platform.getCU().done(function (cu) {
                     cu.disconnect();
                 });


### PR DESCRIPTION
This ensures that there are no limits which are placed on the number of voice commands using the JS library. Currently only 6 voice commands can be issued following which an error occurs. This is the error :  
"Uncaught DOMException: Failed to construct 'AudioContext': The number of hardware contexts provided (6) is greater than or equal to the maximum bound (6)"
Closing the audio context helps in resolving the issue. 